### PR TITLE
Fix(api): Correct font and update cache for social image

### DIFF
--- a/app/api/generateGithubSocial/route.ts
+++ b/app/api/generateGithubSocial/route.ts
@@ -71,9 +71,9 @@ export async function GET(req: NextRequest) {
     GlobalFonts.registerFromPath(pathToFont, 'Impact');
 
     // set the font for the context
-    const font = '80px Roboto'; // impact not used as it is not accessable in vercel
-    const font_small = '60px Roboto';
-    const font_mini = '40px Roboto';
+    const font = '80px Impact';
+    const font_small = '60px Impact';
+    const font_mini = '40px Impact';
 
     // Set the background color
     ctx.fillStyle = '#43475a';
@@ -339,7 +339,7 @@ export async function GET(req: NextRequest) {
     return new NextResponse(image_data, {
       headers: {
         'Content-Type': 'image/png',
-        'Cache-Control': 's-maxage=120, stale-while-revalidate',
+        'Cache-Control': 's-maxage=3600, stale-while-revalidate',
       },
       status: 200,
     });


### PR DESCRIPTION
The generateGithubSocial API endpoint was failing to render text on the generated images in the production environment.

This was caused by the code registering the "Impact" font but then attempting to use the "Roboto" font, which is not available in the Vercel environment. This change corrects the code to use the registered "Impact" font.

Additionally, the cache duration for the API response has been increased from 2 minutes to 1 hour to improve performance and reduce redundant API calls.